### PR TITLE
make ccmpp function flexible to 'mx', 'ax' or 'qx' inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Suggests:
     ggplot2,
     LexisPlotR
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Language: en-US
 Imports: 

--- a/R/ccmpp.R
+++ b/R/ccmpp.R
@@ -45,7 +45,8 @@
 #'
 #' For mortality related inputs, supplying 'survival' only, or two or more of
 #' 'mx', 'qx', and 'ax' is possible. When 'mx', 'qx', and 'ax' parameters are
-#' given then the function calculates the survivorship ratio internally.
+#' given then the function calculates the survivorship ratio with
+#' [nSx_from_lx_nLx_Tx()].
 #'
 #' @section Inputs:
 #' srb: \[`data.table()`\]\cr

--- a/R/ccmpp.R
+++ b/R/ccmpp.R
@@ -4,9 +4,10 @@
 #' method of population projection.
 #'
 #' @param inputs \[`list()`\]\cr
-#'   \[`data.table()`\] for each ccmpp input. Requires 'srb', 'asfr', 'baseline',
-#'   and 'survival'; and migration estimates provided as just 'net_migration' or
-#'   both 'immigration' and 'emigration'. See **Section: Inputs** for more
+#'   \[`data.table()`\] for each ccmpp input. Requires 'srb', 'asfr', 'baseline';
+#'   mortality estimates provided as just 'survival' or two of 'mx', 'ax', and
+#'   'qx'; and migration estimates provided as just 'net_migration' or both
+#'   'immigration' and 'emigration'. See **Section: Inputs** for more
 #'   information on each of the required inputs.
 #' @param settings \[`list()`\]\cr
 #'   Named list of settings for running [ccmpp()] with. See
@@ -41,6 +42,10 @@
 #'
 #' See `vignette("ccmpp", package = "demCore")` or linked references for more
 #' details on this method.
+#'
+#' For mortality related inputs, supplying 'survival' only, or two or more of
+#' 'mx', 'qx', and 'ax' is possible. When 'mx', 'qx', and 'ax' parameters are
+#' given then the function calculates the survivorship ratio internally.
 #'
 #' @section Inputs:
 #' srb: \[`data.table()`\]\cr
@@ -81,6 +86,43 @@
 #'   Corresponds to 'ages' `setting`.
 #'   * age_end: \[`integer()`\] end of the age group (exclusive).
 #'   * `value_col`: \[`numeric()`\] survivorship ratio estimates, must be
+#'   greater than zero and less than one.
+#'
+#' mx: \[`data.table()`\]\cr
+#'   * year_start: \[`integer()`\] start of the calendar year interval
+#'   (inclusive). Corresponds to 'years' `setting`.
+#'   * year_end: \[`integer()`\] end of the calendar year interval (exclusive).
+#'   * sex: \[`character()`\] either 'female' or 'male'. Corresponds to 'sexes'
+#'   `setting`.
+#'   * age_start: \[`integer()`\] start of the age group (inclusive).
+#'   Corresponds to 'ages' `setting`.
+#'   * age_end: \[`integer()`\] end of the age group (exclusive).
+#'   * `value_col`: \[`numeric()`\] mortality rate estimates, must be greater
+#'   than zero.
+#'
+#' ax: \[`data.table()`\]\cr
+#'   * year_start: \[`integer()`\] start of the calendar year interval
+#'   (inclusive). Corresponds to 'years' `setting`.
+#'   * year_end: \[`integer()`\] end of the calendar year interval (exclusive).
+#'   * sex: \[`character()`\] either 'female' or 'male'. Corresponds to 'sexes'
+#'   `setting`.
+#'   * age_start: \[`integer()`\] start of the age group (inclusive).
+#'   Corresponds to 'ages' `setting`.
+#'   * age_end: \[`integer()`\] end of the age group (exclusive).
+#'   * `value_col`: \[`numeric()`\] average years lived by those dying in the
+#'   interval estimates, must be greater than zero and less than the age
+#'   interval length.
+#'
+#' qx: \[`data.table()`\]\cr
+#'   * year_start: \[`integer()`\] start of the calendar year interval
+#'   (inclusive). Corresponds to 'years' `setting`.
+#'   * year_end: \[`integer()`\] end of the calendar year interval (exclusive).
+#'   * sex: \[`character()`\] either 'female' or 'male'. Corresponds to 'sexes'
+#'   `setting`.
+#'   * age_start: \[`integer()`\] start of the age group (inclusive).
+#'   Corresponds to 'ages' `setting`.
+#'   * age_end: \[`integer()`\] end of the age group (exclusive).
+#'   * `value_col`: \[`numeric()`\] probability of death estimates, must be
 #'   greater than zero and less than one.
 #'
 #' net_migration: \[`data.table()`\]\cr
@@ -129,10 +171,10 @@
 #'   * ages: \[`numeric()`\]\cr
 #'   The ages being projected in [demCore::ccmpp()]. Corresponds to the
 #'   'age_start' column in each of the standard age-specific inputs.
-#'   * ages_survival: \[`numeric()`\]\cr
-#'   The ages for which survivorship ratio estimates are available, includes one
+#'   * ages_mortality: \[`numeric()`\]\cr
+#'   The ages for which mortality parameter estimates are available, includes one
 #'   extra age group compared to the 'ages' setting. Corresponds to the
-#'   'age_start' column in the 'survival' \[`data.table()`\] input.
+#'   'age_start' column in the mortality \[`data.table()`\] input(s).
 #'   * ages_asfr: \[`numeric()`\]\cr
 #'   The assumed female reproductive ages, subset of 'ages'. Corresponds to the
 #'   'age_start' column in the age-specific fertility rate (asfr)
@@ -145,7 +187,7 @@
 #'     years = seq(1960, 1995, 5),
 #'     sexes = c("female", "male"),
 #'     ages = seq(0, 80, 5),
-#'     ages_survival = seq(0, 85, 5),
+#'     ages_mortality = seq(0, 85, 5),
 #'     ages_asfr = seq(15, 45, 5)
 #'   )
 #' )
@@ -182,11 +224,40 @@ ccmpp <- function(inputs,
                 value_col)
   pop_all_cols <- c("year", "sex", "age_start", "age_end", value_col)
   if (!gen_end_interval_col) {
-    all_cols <- all_cols[!grepl("_end$", all_cols)]
     pop_all_cols <- pop_all_cols[!grepl("_end$", pop_all_cols)]
   }
   id_cols <- setdiff(all_cols, value_col)
   pop_id_cols <- setdiff(pop_all_cols, value_col)
+
+  # Calculate survivorship ratio if not given -------------------------------
+
+  if (!"survival" %in% names(inputs)) {
+    # calculate all life table parameters
+    inputs <- copy(inputs)
+    params <- c("mx", "qx", "ax")
+    params <- params[params %in% names(inputs)]
+    lifetable_input <- inputs[params]
+    for (param in params) {
+      setnames(lifetable_input[[param]], value_col, param)
+    }
+    lifetable_input <- Reduce(
+      f = function(x, y) merge(x, y, by = id_cols, all = T),
+      x = lifetable_input
+    )
+    lifetable_input <- demCore::lifetable(
+      dt = lifetable_input,
+      id_cols = id_cols
+    )
+    inputs[params] <- NULL
+
+    # calculate survivorship ratio
+    inputs$survival <- demCore::nSx_from_lx_nLx_Tx(
+      dt = lifetable_input,
+      id_cols = id_cols,
+      terminal_age = max(settings$ages)
+    )
+    setnames(inputs$survival, "nSx", value_col)
+  }
 
   # Project population ------------------------------------------------------
 
@@ -454,7 +525,7 @@ validate_ccmpp_inputs <- function(inputs,
                                   value_col) {
 
   # check for all required settings
-  required_settings <- c("years", "sexes", "ages", "ages_survival", "ages_asfr")
+  required_settings <- c("years", "sexes", "ages", "ages_mortality", "ages_asfr")
   assertthat::assert_that(
     all(required_settings %in% names(settings)),
     msg = paste0("Need all required settings: '",
@@ -497,16 +568,16 @@ validate_ccmpp_inputs <- function(inputs,
   )
   int <- unique(diff(settings$ages))
 
-  # check `settings$ages_survival` argument
+  # check `settings$ages_mortality` argument
   assertthat::assert_that(
-    assertive::is_numeric(settings$ages_survival),
-    length(unique(diff(settings$ages_survival))) == 1,
-    unique(diff(settings$ages_survival)) != 0,
-    all(settings$ages %in% settings$ages_survival),
-    max(settings$ages_survival) == max(settings$ages) + int,
-    msg = paste0("`settings$ages_survival` must be a numeric vector defining ",
+    assertive::is_numeric(settings$ages_mortality),
+    length(unique(diff(settings$ages_mortality))) == 1,
+    unique(diff(settings$ages_mortality)) != 0,
+    all(settings$ages %in% settings$ages_mortality),
+    max(settings$ages_mortality) == max(settings$ages) + int,
+    msg = paste0("`settings$ages_mortality` must be a numeric vector defining ",
                  "the start of evenly spaced age group intervals for the ",
-                 "survivorship ratio estimates")
+                 "mortality related estimates")
   )
 
   # check `settings$ages_asfr` argument
@@ -533,11 +604,14 @@ validate_ccmpp_inputs <- function(inputs,
   # check all required components are present in `inputs`
   components <- names(inputs)
   assertthat::assert_that(
-    all(c("srb", "asfr", "baseline", "survival") %in% components),
-    "net_migration" %in% components |
-      all(c("immigration", "emigration") %in% components),
+    all(c("srb", "asfr", "baseline") %in% components),
+    xor("survival" %in% components,
+        data.table::between(length(setdiff(c("mx", "qx", "ax"), components)), 0, 1)),
+    xor("net_migration" %in% components,
+        all(c("immigration", "emigration") %in% components)),
     msg = "`inputs` requires named components for each of 'srb', 'asfr',
-    'baseline', and 'survival'; and migration estimates provided as just
+    'baseline'; and mortality estimates provided as just 'survival' or at least
+    two of 'mx', 'qx, and 'ax'; and migration estimates provided as just
     'net_migration' or 'immigration' and 'emigration'."
   )
 
@@ -550,6 +624,9 @@ validate_ccmpp_inputs <- function(inputs,
     "asfr" = setdiff(all_cols, "sex"),
     "baseline" = pop_all_cols,
     "survival" = all_cols,
+    "mx" = all_cols,
+    "qx" = all_cols,
+    "ax" = all_cols,
     "net_migration" = all_cols,
     "immigration" = all_cols,
     "emigration" = all_cols
@@ -564,7 +641,16 @@ validate_ccmpp_inputs <- function(inputs,
                       age_start = settings$ages),
     "survival" = list(year_start = settings$years,
                       sex = settings$sexes,
-                      age_start = settings$ages_survival),
+                      age_start = settings$ages_mortality),
+    "mx" = list(year_start = settings$years,
+                      sex = settings$sexes,
+                      age_start = settings$ages_mortality),
+    "qx" = list(year_start = settings$years,
+                      sex = settings$sexes,
+                      age_start = settings$ages_mortality),
+    "ax" = list(year_start = settings$years,
+                      sex = settings$sexes,
+                      age_start = settings$ages_mortality),
     "net_migration" = list(year_start = settings$years,
                            sex = settings$sexes,
                            age_start = settings$ages),
@@ -600,10 +686,29 @@ validate_ccmpp_inputs <- function(inputs,
                             test = "gte", test_val = "0", quiet = T)
   assertable::assert_values(inputs[["baseline"]], colnames = value_col,
                             test = "gte", test_val = "0", quiet = T)
-  assertable::assert_values(inputs[["survival"]], colnames = value_col,
-                            test = "gte", test_val = "0", quiet = T)
-  assertable::assert_values(inputs[["survival"]], colnames = value_col,
-                            test = "lte", test_val = "1", quiet = T)
+  if ("survival" %in% components) {
+    assertable::assert_values(inputs[["survival"]], colnames = value_col,
+                              test = "gte", test_val = "0", quiet = T)
+    assertable::assert_values(inputs[["survival"]], colnames = value_col,
+                              test = "lte", test_val = "1", quiet = T)
+  } else {
+    if ("mx" %in% components) {
+      assertable::assert_values(inputs[["mx"]], colnames = value_col,
+                                test = "gte", test_val = "0", quiet = T)
+    }
+    if ("qx" %in% components) {
+      assertable::assert_values(inputs[["qx"]], colnames = value_col,
+                                test = "gte", test_val = "0", quiet = T)
+      assertable::assert_values(inputs[["qx"]], colnames = value_col,
+                                test = "lte", test_val = "1", quiet = T)
+    }
+    if ("ax" %in% components) {
+      assertable::assert_values(inputs[["ax"]], colnames = value_col,
+                                test = "gte", test_val = "0", quiet = T)
+      assertable::assert_values(inputs[["ax"]][!is.infinite(age_end)], colnames = value_col,
+                                test = "lte", test_val = int, quiet = T)
+    }
+  }
   if (!"net_migration" %in% components) {
     assertable::assert_values(inputs[["immigration"]], colnames = value_col,
                               test = "gte", test_val = "0", quiet = T)

--- a/man/agg_lt.Rd
+++ b/man/agg_lt.Rd
@@ -28,10 +28,14 @@ specified in the input life tables \code{dt}.}
 
 \item{missing_dt_severity}{[\code{character(1)}]\cr
 How severe should the consequences of missing data that prevents
-aggregation or scaling from occurring be? Can be either 'skip', 'stop',
-'warning', 'message', or 'none'. If 'skip', the checks for missing data are
-skipped. If not 'stop', then only the possible aggregations or scaling is
-done using the available data.}
+aggregation or scaling from occurring be? Can be either 'stop', 'warning',
+'message', or 'none'. If not "stop", then only the possible aggregations or
+scaling is done using the available data.}
+
+\item{drop_present_aggs}{[\code{logical(1)}]\cr
+Whether to drop aggregates (or overlapping intervals) that are already
+present in \code{dt} before aggregating. Default is 'False' and the function
+errors out.}
 }
 \value{
 [\code{data.table()}]\cr Aggregated life table(s) with columns for all
@@ -140,5 +144,5 @@ dt <- agg_lt(
 )
 }
 \seealso{
-\code{\link[hierarchyUtils:agg]{hierarchyUtils::agg()}}
+\code{\link[hierarchyUtils:agg_scale]{hierarchyUtils::agg()}}
 }

--- a/man/burkina_faso.Rd
+++ b/man/burkina_faso.Rd
@@ -80,6 +80,49 @@ Corresponds to 'ages' \code{setting}.
 greater than zero and less than one.
 }
 
+mx: [\code{data.table()}]\cr
+\itemize{
+\item year_start: [\code{integer()}] start of the calendar year interval
+(inclusive). Corresponds to 'years' \code{setting}.
+\item year_end: [\code{integer()}] end of the calendar year interval (exclusive).
+\item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
+\code{setting}.
+\item age_start: [\code{integer()}] start of the age group (inclusive).
+Corresponds to 'ages' \code{setting}.
+\item age_end: [\code{integer()}] end of the age group (exclusive).
+\item \code{value_col}: [\code{numeric()}] mortality rate estimates, must be greater
+than zero.
+}
+
+ax: [\code{data.table()}]\cr
+\itemize{
+\item year_start: [\code{integer()}] start of the calendar year interval
+(inclusive). Corresponds to 'years' \code{setting}.
+\item year_end: [\code{integer()}] end of the calendar year interval (exclusive).
+\item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
+\code{setting}.
+\item age_start: [\code{integer()}] start of the age group (inclusive).
+Corresponds to 'ages' \code{setting}.
+\item age_end: [\code{integer()}] end of the age group (exclusive).
+\item \code{value_col}: [\code{numeric()}] average years lived by those dying in the
+interval estimates, must be greater than zero and less than the age
+interval length.
+}
+
+qx: [\code{data.table()}]\cr
+\itemize{
+\item year_start: [\code{integer()}] start of the calendar year interval
+(inclusive). Corresponds to 'years' \code{setting}.
+\item year_end: [\code{integer()}] end of the calendar year interval (exclusive).
+\item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
+\code{setting}.
+\item age_start: [\code{integer()}] start of the age group (inclusive).
+Corresponds to 'ages' \code{setting}.
+\item age_end: [\code{integer()}] end of the age group (exclusive).
+\item \code{value_col}: [\code{numeric()}] probability of death estimates, must be
+greater than zero and less than one.
+}
+
 net_migration: [\code{data.table()}]\cr
 \itemize{
 \item year_start: [\code{integer()}] start of the calendar year interval

--- a/man/ccmpp.Rd
+++ b/man/ccmpp.Rd
@@ -15,9 +15,10 @@ ccmpp(
 }
 \arguments{
 \item{inputs}{[\code{list()}]\cr
-[\code{data.table()}] for each ccmpp input. Requires 'srb', 'asfr', 'baseline',
-and 'survival'; and migration estimates provided as just 'net_migration' or
-both 'immigration' and 'emigration'. See \strong{Section: Inputs} for more
+[\code{data.table()}] for each ccmpp input. Requires 'srb', 'asfr', 'baseline';
+mortality estimates provided as just 'survival' or two of 'mx', 'ax', and
+'qx'; and migration estimates provided as just 'net_migration' or both
+'immigration' and 'emigration'. See \strong{Section: Inputs} for more
 information on each of the required inputs.}
 
 \item{settings}{[\code{list()}]\cr
@@ -62,6 +63,10 @@ birth, and mortality.
 
 See \code{vignette("ccmpp", package = "demCore")} or linked references for more
 details on this method.
+
+For mortality related inputs, supplying 'survival' only, or two or more of
+'mx', 'qx', and 'ax' is possible. When 'mx', 'qx', and 'ax' parameters are
+given then the function calculates the survivorship ratio internally.
 }
 \section{Inputs}{
 
@@ -113,6 +118,49 @@ Corresponds to 'ages' \code{setting}.
 greater than zero and less than one.
 }
 
+mx: [\code{data.table()}]\cr
+\itemize{
+\item year_start: [\code{integer()}] start of the calendar year interval
+(inclusive). Corresponds to 'years' \code{setting}.
+\item year_end: [\code{integer()}] end of the calendar year interval (exclusive).
+\item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
+\code{setting}.
+\item age_start: [\code{integer()}] start of the age group (inclusive).
+Corresponds to 'ages' \code{setting}.
+\item age_end: [\code{integer()}] end of the age group (exclusive).
+\item \code{value_col}: [\code{numeric()}] mortality rate estimates, must be greater
+than zero.
+}
+
+ax: [\code{data.table()}]\cr
+\itemize{
+\item year_start: [\code{integer()}] start of the calendar year interval
+(inclusive). Corresponds to 'years' \code{setting}.
+\item year_end: [\code{integer()}] end of the calendar year interval (exclusive).
+\item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
+\code{setting}.
+\item age_start: [\code{integer()}] start of the age group (inclusive).
+Corresponds to 'ages' \code{setting}.
+\item age_end: [\code{integer()}] end of the age group (exclusive).
+\item \code{value_col}: [\code{numeric()}] average years lived by those dying in the
+interval estimates, must be greater than zero and less than the age
+interval length.
+}
+
+qx: [\code{data.table()}]\cr
+\itemize{
+\item year_start: [\code{integer()}] start of the calendar year interval
+(inclusive). Corresponds to 'years' \code{setting}.
+\item year_end: [\code{integer()}] end of the calendar year interval (exclusive).
+\item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
+\code{setting}.
+\item age_start: [\code{integer()}] start of the age group (inclusive).
+Corresponds to 'ages' \code{setting}.
+\item age_end: [\code{integer()}] end of the age group (exclusive).
+\item \code{value_col}: [\code{numeric()}] probability of death estimates, must be
+greater than zero and less than one.
+}
+
 net_migration: [\code{data.table()}]\cr
 \itemize{
 \item year_start: [\code{integer()}] start of the calendar year interval
@@ -159,19 +207,19 @@ be greater than zero.
 
 \itemize{
 \item years: [\code{numeric()}]\cr
-The start of each calendar year interval to project in \code{\link[demCore:ccmpp]{demCore::ccmpp()}}.
+The start of each calendar year interval to project in \code{\link[=ccmpp]{ccmpp()}}.
 Corresponds to the 'year_start' column in each of the year-specific inputs.
 \item sexes: [\code{character()}]\cr
-The sexes being projected in \code{\link[demCore:ccmpp]{demCore::ccmpp()}}, must be either just
+The sexes being projected in \code{\link[=ccmpp]{ccmpp()}}, must be either just
 'female', or 'female' and 'male'. Corresponds to the 'sex' column in each
 of the sex-specific inputs.
 \item ages: [\code{numeric()}]\cr
-The ages being projected in \code{\link[demCore:ccmpp]{demCore::ccmpp()}}. Corresponds to the
+The ages being projected in \code{\link[=ccmpp]{ccmpp()}}. Corresponds to the
 'age_start' column in each of the standard age-specific inputs.
-\item ages_survival: [\code{numeric()}]\cr
-The ages for which survivorship ratio estimates are available, includes one
+\item ages_mortality: [\code{numeric()}]\cr
+The ages for which mortality parameter estimates are available, includes one
 extra age group compared to the 'ages' setting. Corresponds to the
-'age_start' column in the 'survival' [\code{data.table()}] input.
+'age_start' column in the mortality [\code{data.table()}] input(s).
 \item ages_asfr: [\code{numeric()}]\cr
 The assumed female reproductive ages, subset of 'ages'. Corresponds to the
 'age_start' column in the age-specific fertility rate (asfr)
@@ -186,7 +234,7 @@ population <- ccmpp(
     years = seq(1960, 1995, 5),
     sexes = c("female", "male"),
     ages = seq(0, 80, 5),
-    ages_survival = seq(0, 85, 5),
+    ages_mortality = seq(0, 85, 5),
     ages_asfr = seq(15, 45, 5)
   )
 )

--- a/man/ccmpp.Rd
+++ b/man/ccmpp.Rd
@@ -66,7 +66,8 @@ details on this method.
 
 For mortality related inputs, supplying 'survival' only, or two or more of
 'mx', 'qx', and 'ax' is possible. When 'mx', 'qx', and 'ax' parameters are
-given then the function calculates the survivorship ratio internally.
+given then the function calculates the survivorship ratio with
+\code{\link[=nSx_from_lx_nLx_Tx]{nSx_from_lx_nLx_Tx()}}.
 }
 \section{Inputs}{
 

--- a/man/gen_lifetable_parameters.Rd
+++ b/man/gen_lifetable_parameters.Rd
@@ -112,8 +112,8 @@ gen_qx_from_lx(dt, id_cols = c("sex", "age_start", "age_end"))
 }
 \seealso{
 \itemize{
-\item{\link[demCore:mx_qx_ax_conversions]{demCore::mx_qx_ax_conversions}}
-\item{\link[demCore:lifetable]{demCore::lifetable}}
+\item{\link{mx_qx_ax_conversions}}
+\item{\link{lifetable}}
 \item \code{vignette("introduction_to_life_tables", package = "demCore")}
 }
 }

--- a/man/gen_u5_ax_from_qx.Rd
+++ b/man/gen_u5_ax_from_qx.Rd
@@ -33,7 +33,7 @@ Takes a \code{data.table} with 'age_start', 'age_end', 'sex', and
 infant probability of death ('qx') and adds a column 'ax'. There is no
 absolute relationship between ax and qx without mx also known. Instead,
 this function performs an inverse calculation of the calculation described
-for \code{\link[demCore:gen_u5_ax_from_mx]{demCore::gen_u5_ax_from_mx()}} which estimates ax from 1m0. Since
+for \code{\link[=gen_u5_ax_from_mx]{gen_u5_ax_from_mx()}} which estimates ax from 1m0. Since
 the inverse involves a quadratic, we use \code{\link[stats:uniroot]{stats::uniroot()}} to find the
 solution.
 }
@@ -51,5 +51,5 @@ Preston Samuel H, Patrick H, Michel G. Demography: measuring and modeling
 population processes. MA: Blackwell Publishing. 2001.
 }
 \seealso{
-\code{\link[demCore:gen_u5_ax_from_mx]{demCore::gen_u5_ax_from_mx()}}
+\code{\link[=gen_u5_ax_from_mx]{gen_u5_ax_from_mx()}}
 }

--- a/man/scale_qx.Rd
+++ b/man/scale_qx.Rd
@@ -18,10 +18,9 @@ ID columns that uniquely identify each row of \code{dt}.}
 
 \item{missing_dt_severity}{[\code{character(1)}]\cr
 How severe should the consequences of missing data that prevents
-aggregation or scaling from occurring be? Can be either 'skip', 'stop',
-'warning', 'message', or 'none'. If 'skip', the checks for missing data are
-skipped. If not 'stop', then only the possible aggregations or scaling is
-done using the available data.}
+aggregation or scaling from occurring be? Can be either 'stop', 'warning',
+'message', or 'none'. If not "stop", then only the possible aggregations or
+scaling is done using the available data.}
 }
 \value{
 [\code{data.table()}]\cr Scaled qx values, has \code{id_cols} and 'qx'
@@ -34,14 +33,14 @@ interval qx values already present in the data.
 \details{
 Convert to px-space, scale up age-hierarchy so that granular px
 values multiply to aggregate px values, convert back to qx-space.
-\code{scale_qx()} is a wrapper for \code{\link[hierarchyUtils:scale]{hierarchyUtils::scale()}}.
+\code{scale_qx()} is a wrapper for \code{\link[hierarchyUtils:agg_scale]{hierarchyUtils::scale()}}.
 
 This function is unique to aggregating and scaling qx over age because of
 the dependence between age and the definition of qx. Aggregation of qx
 across sex, location, or other variables should be done by first aggregating
-ax and mx as population-weighted means (can use \code{\link[hierarchyUtils:agg]{hierarchyUtils::agg()}} and
-\code{\link[hierarchyUtils:scale]{hierarchyUtils::scale()}} directly), then recalculating qx from mx and ax
-(see \code{\link[demCore:mx_ax_to_qx]{demCore::mx_ax_to_qx()}}).
+ax and mx as population-weighted means (can use \code{\link[hierarchyUtils:agg_scale]{hierarchyUtils::agg()}} and
+\code{\link[hierarchyUtils:agg_scale]{hierarchyUtils::scale()}} directly), then recalculating qx from mx and ax
+(see \code{\link[=mx_ax_to_qx]{mx_ax_to_qx()}}).
 }
 \examples{
 # scale qx up single-year to abridged u5 hierarchy

--- a/man/thailand.Rd
+++ b/man/thailand.Rd
@@ -80,6 +80,49 @@ Corresponds to 'ages' \code{setting}.
 greater than zero and less than one.
 }
 
+mx: [\code{data.table()}]\cr
+\itemize{
+\item year_start: [\code{integer()}] start of the calendar year interval
+(inclusive). Corresponds to 'years' \code{setting}.
+\item year_end: [\code{integer()}] end of the calendar year interval (exclusive).
+\item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
+\code{setting}.
+\item age_start: [\code{integer()}] start of the age group (inclusive).
+Corresponds to 'ages' \code{setting}.
+\item age_end: [\code{integer()}] end of the age group (exclusive).
+\item \code{value_col}: [\code{numeric()}] mortality rate estimates, must be greater
+than zero.
+}
+
+ax: [\code{data.table()}]\cr
+\itemize{
+\item year_start: [\code{integer()}] start of the calendar year interval
+(inclusive). Corresponds to 'years' \code{setting}.
+\item year_end: [\code{integer()}] end of the calendar year interval (exclusive).
+\item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
+\code{setting}.
+\item age_start: [\code{integer()}] start of the age group (inclusive).
+Corresponds to 'ages' \code{setting}.
+\item age_end: [\code{integer()}] end of the age group (exclusive).
+\item \code{value_col}: [\code{numeric()}] average years lived by those dying in the
+interval estimates, must be greater than zero and less than the age
+interval length.
+}
+
+qx: [\code{data.table()}]\cr
+\itemize{
+\item year_start: [\code{integer()}] start of the calendar year interval
+(inclusive). Corresponds to 'years' \code{setting}.
+\item year_end: [\code{integer()}] end of the calendar year interval (exclusive).
+\item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
+\code{setting}.
+\item age_start: [\code{integer()}] start of the age group (inclusive).
+Corresponds to 'ages' \code{setting}.
+\item age_end: [\code{integer()}] end of the age group (exclusive).
+\item \code{value_col}: [\code{numeric()}] probability of death estimates, must be
+greater than zero and less than one.
+}
+
 net_migration: [\code{data.table()}]\cr
 \itemize{
 \item year_start: [\code{integer()}] start of the calendar year interval

--- a/man/validate_ccmpp_inputs.Rd
+++ b/man/validate_ccmpp_inputs.Rd
@@ -8,9 +8,10 @@ validate_ccmpp_inputs(inputs, settings, value_col)
 }
 \arguments{
 \item{inputs}{[\code{list()}]\cr
-[\code{data.table()}] for each ccmpp input. Requires 'srb', 'asfr', 'baseline',
-and 'survival'; and migration estimates provided as just 'net_migration' or
-both 'immigration' and 'emigration'. See \strong{Section: Inputs} for more
+[\code{data.table()}] for each ccmpp input. Requires 'srb', 'asfr', 'baseline';
+mortality estimates provided as just 'survival' or two of 'mx', 'ax', and
+'qx'; and migration estimates provided as just 'net_migration' or both
+'immigration' and 'emigration'. See \strong{Section: Inputs} for more
 information on each of the required inputs.}
 
 \item{settings}{[\code{list()}]\cr

--- a/tests/testthat/test_ccmpp.R
+++ b/tests/testthat/test_ccmpp.R
@@ -18,7 +18,7 @@ test_that("test that `ccmpp` gives expected output", {
       years = seq(1960, 1995, 5),
       sexes = c("female", "male"),
       ages = seq(0, 80, 5),
-      ages_survival = seq(0, 85, 5),
+      ages_mortality = seq(0, 85, 5),
       ages_asfr = seq(15, 45, 5)
     )
   )
@@ -49,7 +49,51 @@ test_that("test that `ccmpp` gives expected output with immigration/emigration",
       years = seq(1960, 1995, 5),
       sexes = c("female", "male"),
       ages = seq(0, 80, 5),
-      ages_survival = seq(0, 85, 5),
+      ages_mortality = seq(0, 85, 5),
+      ages_asfr = seq(15, 45, 5)
+    )
+  )
+  assertable::assert_ids(
+    data = population,
+    id_vars = list(year = seq(1960, 2000, 5),
+                   sex = c("female", "male"),
+                   age_start = seq(0, 80, 5)),
+    quiet = T
+  )
+  testthat::expect_identical(
+    names(population),
+    c("year", "sex", "age_start", "age_end", "value")
+  )
+})
+
+test_that("test that `ccmpp` works with 'mx', 'ax', 'qx' inputs", {
+
+  # create rough inputs for mx and ax
+  lt <- copy(demCore::thailand_initial_estimates$survival)
+  # px approximately equal to survivorship ratio
+  lt[, qx := 1 - value]
+  lt[, value := NULL]
+  lt[is.infinite(age_end), qx := 1]
+  # assign default ax values
+  lt[, ax := 2.5]
+  id_cols <- c("year_start", "year_end", "sex", "age_start", "age_end")
+  demCore::lifetable(lt, id_cols = id_cols)
+
+  # add inputs for mx and ax
+  new_inputs <- copy(demCore::thailand_initial_estimates)
+  new_inputs$mx <- lt[, .SD, .SDcols = c(id_cols, "mx")]
+  setnames(new_inputs$mx, "mx", "value")
+  new_inputs$ax <- lt[, .SD, .SDcols = c(id_cols, "ax")]
+  setnames(new_inputs$ax, "ax", "value")
+  new_inputs$survival <- NULL
+
+  population <- ccmpp(
+    inputs = new_inputs,
+    settings = list(
+      years = seq(1960, 1995, 5),
+      sexes = c("female", "male"),
+      ages = seq(0, 80, 5),
+      ages_mortality = seq(0, 85, 5),
       ages_asfr = seq(15, 45, 5)
     )
   )

--- a/vignettes/ccmpp.Rmd
+++ b/vignettes/ccmpp.Rmd
@@ -75,7 +75,7 @@ thailand_settings <- list(
   years = seq(1960, 1995, 5),
   sexes = c("female", "male"),
   ages = seq(0, 80, 5),
-  ages_survival = seq(0, 85, 5),
+  ages_mortality = seq(0, 85, 5),
   ages_asfr = seq(15, 45, 5)
 )
 ```


### PR DESCRIPTION
## Describe changes

This allows `ccmpp` to use basic lifetable parameters as input.

Now instead of requiring survivorship ratio estimates `ccmpp` can use inputs from two or more of the basic lifetable parameters ('mx', 'ax', or 'qx') to internally calculate the survivorship ratio.

## What issues are related

Related to https://github.com/ihmeuw-demographics/popMethods/pull/22

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [X] Have you successfully run `devtools::check()` locally?
* [X] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [X] Have you added in tests for the changes included in the PR?
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.
