### PR TITLE
make determining age specific matrices more specific

### DIFF
--- a/man/dt_matrix_format.Rd
+++ b/man/dt_matrix_format.Rd
@@ -74,9 +74,11 @@ have a column for 'sex', and if the data is age-specific it must have
 columns for 'age_start' and 'age_end.
 
 matrix format: When data is in matrix format, columns represent the start of
-each calendar year interval, rows represent the start of each age interval
-and if the data is sex specific each sex will have a separate matrix stored
-in a named list (names corresponding to each sex).
+each calendar year interval, rows represent the start of each age interval.
+If the data is sex specific each sex will have a separate matrix stored
+in a named list (names corresponding to each sex). If the data is age
+specific rows will be labeled with a numeric representing the start of the
+age group.
 }
 \examples{
 output_matrix <- demCore:::dt_to_matrix(thailand_initial_estimates$survival)

--- a/tests/testthat/test-matrix_dt_formatting.R
+++ b/tests/testthat/test-matrix_dt_formatting.R
@@ -6,6 +6,13 @@ testthat::test_that("check `matrix_dt_formatting functions work", {
   data.table::setindexv(thailand_initial_estimates$survival, NULL)
   testthat::expect_equal(thailand_initial_estimates$survival, output_dt)
 
+  # check with age and sex-specific data with only the terminal age group
+  input_dt <- thailand_initial_estimates$survival[is.infinite(age_end)]
+  output_matrix <- dt_to_matrix(input_dt)
+  output_dt <- matrix_to_dt(output_matrix, year_right_most_endpoint = 2000)
+  data.table::setindexv(input_dt, NULL)
+  testthat::expect_equal(input_dt, output_dt)
+
   # check with non age or sex-specific data
   output_matrix <- dt_to_matrix(thailand_initial_estimates$srb,
                                 id_cols = c("year_start", "year_end"))


### PR DESCRIPTION
## Describe changes

This is specifically to resolve converting `srb` and `terminal_ax` matrices to data.table in popMethods. 

These functions assume columns correspond to years and rows correspond to ages. Previously it was assumed if there was just one row then the matrix was not age-specific and no `age_start` column would be included in the resulting data.table. This PR makes it so that if the rownames of the input matrix contain numeric names then it is assumed to be age specific.

## What issues are related

Related to https://github.com/ihmeuw-demographics/popMethods/pull/22

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [X] Have you successfully run `devtools::check()` locally?
* [X] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [X] Have you added in tests for the changes included in the PR?
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.