### PR TITLE
add flexibility to ccmpp to allow 'ages_mortality' to be equal to 'ages'

### DIFF
--- a/R/ccmpp.R
+++ b/R/ccmpp.R
@@ -173,8 +173,10 @@
 #'   The ages being projected in [demCore::ccmpp()]. Corresponds to the
 #'   'age_start' column in each of the standard age-specific inputs.
 #'   * ages_mortality: \[`numeric()`\]\cr
-#'   The ages for which mortality parameter estimates are available, includes one
-#'   extra age group compared to the 'ages' setting. Corresponds to the
+#'   The ages for which mortality parameter estimates are available. Must either
+#'   be equivalent to 'ages' or include one extra older age group. See the
+#'   [vignette](https://ihmeuw-demographics.github.io/demCore/articles/ccmpp.html#ccmpp-for-the-terminal-age-group-with-out-migration)
+#'   for the approximation made when 'ages = ages_mortality'. Corresponds to the
 #'   'age_start' column in the mortality \[`data.table()`\] input(s).
 #'   * ages_asfr: \[`numeric()`\]\cr
 #'   The assumed female reproductive ages, subset of 'ages'. Corresponds to the

--- a/R/ccmpp.R
+++ b/R/ccmpp.R
@@ -84,7 +84,7 @@
 #'   * sex: \[`character()`\] either 'female' or 'male'. Corresponds to 'sexes'
 #'   `setting`.
 #'   * age_start: \[`integer()`\] start of the age group (inclusive).
-#'   Corresponds to 'ages' `setting`.
+#'   Corresponds to 'ages_mortality' `setting`.
 #'   * age_end: \[`integer()`\] end of the age group (exclusive).
 #'   * `value_col`: \[`numeric()`\] survivorship ratio estimates, must be
 #'   greater than zero and less than one.
@@ -96,7 +96,7 @@
 #'   * sex: \[`character()`\] either 'female' or 'male'. Corresponds to 'sexes'
 #'   `setting`.
 #'   * age_start: \[`integer()`\] start of the age group (inclusive).
-#'   Corresponds to 'ages' `setting`.
+#'   Corresponds to 'ages_mortality' `setting`.
 #'   * age_end: \[`integer()`\] end of the age group (exclusive).
 #'   * `value_col`: \[`numeric()`\] mortality rate estimates, must be greater
 #'   than zero.
@@ -108,7 +108,7 @@
 #'   * sex: \[`character()`\] either 'female' or 'male'. Corresponds to 'sexes'
 #'   `setting`.
 #'   * age_start: \[`integer()`\] start of the age group (inclusive).
-#'   Corresponds to 'ages' `setting`.
+#'   Corresponds to 'ages_mortality' `setting`.
 #'   * age_end: \[`integer()`\] end of the age group (exclusive).
 #'   * `value_col`: \[`numeric()`\] average years lived by those dying in the
 #'   interval estimates, must be greater than zero and less than the age
@@ -121,7 +121,7 @@
 #'   * sex: \[`character()`\] either 'female' or 'male'. Corresponds to 'sexes'
 #'   `setting`.
 #'   * age_start: \[`integer()`\] start of the age group (inclusive).
-#'   Corresponds to 'ages' `setting`.
+#'   Corresponds to 'ages_mortality' `setting`.
 #'   * age_end: \[`integer()`\] end of the age group (exclusive).
 #'   * `value_col`: \[`numeric()`\] probability of death estimates, must be
 #'   greater than zero and less than one.
@@ -404,9 +404,9 @@ ccmpp <- function(inputs,
 #' @description Constructs the Leslie matrix needed for cohort component method
 #' of population projection [`ccmpp()`].
 #'
-#' @param survival \[`numeric(n_ages + 1)`\]\cr
+#' @param survival \[`numeric(n_ages + 1)` or `numeric(n_ages)`\]\cr
 #'   Survivorship ratio, the proportion of people aged x - `int` that will be
-#'   alive `int` years later in a stationary population
+#'   alive `int` years later in a stationary population.
 #' @param asfr \[`numeric(n_ages)`\]\cr
 #'   Annual age specific fertility rates NOT yet multiplied by `int`. Must
 #'   include both reproductive and non-reproductive age groups that are zero.
@@ -469,9 +469,10 @@ leslie_matrix <- function(survival,
   # check `survival` argument
   assertthat::assert_that(
     assertive::is_numeric(survival),
-    length(survival) == n_ages + 1,
-    msg = "`survival` must be a numeric of length `n_ages` + 1"
+    length(survival) %in% c(n_ages, n_ages + 1),
+    msg = "`survival` must be a numeric of length `n_ages` or (`n_ages` + 1)"
   )
+  if (length(survival) == n_ages) survival[n_ages + 1] <- survival[n_ages]
 
   # check `asfr` argument
   assertthat::assert_that(
@@ -505,7 +506,7 @@ leslie_matrix <- function(survival,
   }
 
   # other rows include survivorship ratios
-  leslie[2:n_ages, 1:(n_ages - 1)] <- diag(survival[-c(1, n_ages + 1)])
+  leslie[2:n_ages, 1:(n_ages - 1)] <- diag(survival[2:n_ages])
   leslie[n_ages, n_ages] <- survival[n_ages + 1]
 
   # label columns and rows
@@ -575,7 +576,7 @@ validate_ccmpp_inputs <- function(inputs,
     length(unique(diff(settings$ages_mortality))) == 1,
     unique(diff(settings$ages_mortality)) != 0,
     all(settings$ages %in% settings$ages_mortality),
-    max(settings$ages_mortality) == max(settings$ages) + int,
+    max(settings$ages_mortality) %in% c(max(settings$ages), max(settings$ages) + int),
     msg = paste0("`settings$ages_mortality` must be a numeric vector defining ",
                  "the start of evenly spaced age group intervals for the ",
                  "mortality related estimates")

--- a/man/burkina_faso.Rd
+++ b/man/burkina_faso.Rd
@@ -74,7 +74,7 @@ survival: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] survivorship ratio estimates, must be
 greater than zero and less than one.
@@ -88,7 +88,7 @@ mx: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] mortality rate estimates, must be greater
 than zero.
@@ -102,7 +102,7 @@ ax: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] average years lived by those dying in the
 interval estimates, must be greater than zero and less than the age
@@ -117,7 +117,7 @@ qx: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] probability of death estimates, must be
 greater than zero and less than one.

--- a/man/ccmpp.Rd
+++ b/man/ccmpp.Rd
@@ -218,8 +218,10 @@ of the sex-specific inputs.
 The ages being projected in \code{\link[=ccmpp]{ccmpp()}}. Corresponds to the
 'age_start' column in each of the standard age-specific inputs.
 \item ages_mortality: [\code{numeric()}]\cr
-The ages for which mortality parameter estimates are available, includes one
-extra age group compared to the 'ages' setting. Corresponds to the
+The ages for which mortality parameter estimates are available. Must either
+be equivalent to 'ages' or include one extra older age group. See the
+\href{https://ihmeuw-demographics.github.io/demCore/articles/ccmpp.html#ccmpp-for-the-terminal-age-group-with-out-migration}{vignette}
+for the approximation made when 'ages = ages_mortality'. Corresponds to the
 'age_start' column in the mortality [\code{data.table()}] input(s).
 \item ages_asfr: [\code{numeric()}]\cr
 The assumed female reproductive ages, subset of 'ages'. Corresponds to the

--- a/man/ccmpp.Rd
+++ b/man/ccmpp.Rd
@@ -113,7 +113,7 @@ survival: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] survivorship ratio estimates, must be
 greater than zero and less than one.
@@ -127,7 +127,7 @@ mx: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] mortality rate estimates, must be greater
 than zero.
@@ -141,7 +141,7 @@ ax: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] average years lived by those dying in the
 interval estimates, must be greater than zero and less than the age
@@ -156,7 +156,7 @@ qx: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] probability of death estimates, must be
 greater than zero and less than one.

--- a/man/leslie_matrix.Rd
+++ b/man/leslie_matrix.Rd
@@ -7,9 +7,9 @@
 leslie_matrix(survival, asfr, srb, n_ages, int, female)
 }
 \arguments{
-\item{survival}{[\code{numeric(n_ages + 1)}]\cr
+\item{survival}{[\code{numeric(n_ages + 1)} or \code{numeric(n_ages)}]\cr
 Survivorship ratio, the proportion of people aged x - \code{int} that will be
-alive \code{int} years later in a stationary population}
+alive \code{int} years later in a stationary population.}
 
 \item{asfr}{[\code{numeric(n_ages)}]\cr
 Annual age specific fertility rates NOT yet multiplied by \code{int}. Must

--- a/man/thailand.Rd
+++ b/man/thailand.Rd
@@ -74,7 +74,7 @@ survival: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] survivorship ratio estimates, must be
 greater than zero and less than one.
@@ -88,7 +88,7 @@ mx: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] mortality rate estimates, must be greater
 than zero.
@@ -102,7 +102,7 @@ ax: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] average years lived by those dying in the
 interval estimates, must be greater than zero and less than the age
@@ -117,7 +117,7 @@ qx: [\code{data.table()}]\cr
 \item sex: [\code{character()}] either 'female' or 'male'. Corresponds to 'sexes'
 \code{setting}.
 \item age_start: [\code{integer()}] start of the age group (inclusive).
-Corresponds to 'ages' \code{setting}.
+Corresponds to 'ages_mortality' \code{setting}.
 \item age_end: [\code{integer()}] end of the age group (exclusive).
 \item \code{value_col}: [\code{numeric()}] probability of death estimates, must be
 greater than zero and less than one.

--- a/tests/testthat/test_ccmpp.R
+++ b/tests/testthat/test_ccmpp.R
@@ -1,7 +1,9 @@
 test_that("test that `leslie_matrix` gives expected output", {
   leslie <- leslie_matrix(
-    survival = thailand_initial_estimates$survival[year_start == 1960 &
-                                                     sex == "female", value],
+    survival = thailand_initial_estimates$survival[
+      year_start == 1960 & sex == "female",
+      value
+    ],
     asfr = c(rep(0, 3),
              thailand_initial_estimates$asfr[year_start == 1960, value],
              rep(0, 7)),
@@ -9,6 +11,21 @@ test_that("test that `leslie_matrix` gives expected output", {
     n_ages = 17, int = 5, female = TRUE
   )
   testthat::expect_identical(dim(leslie), c(17L, 17L))
+
+  # use 80+ survival
+  leslie <- leslie_matrix(
+    survival = thailand_initial_estimates$survival[
+      year_start == 1960 & sex == "female" & age_start <= 80,
+      value
+    ],
+    asfr = c(rep(0, 3),
+             thailand_initial_estimates$asfr[year_start == 1960, value],
+             rep(0, 7)),
+    srb = thailand_initial_estimates$srb[year_start == 1960, value],
+    n_ages = 17, int = 5, female = TRUE
+  )
+  testthat::expect_identical(dim(leslie), c(17L, 17L))
+  testthat::expect_identical(leslie[17, 16], leslie[17, 17])
 })
 
 test_that("test that `ccmpp` gives expected output", {
@@ -33,6 +50,32 @@ test_that("test that `ccmpp` gives expected output", {
     names(population),
     c("year", "sex", "age_start", "age_end", "value")
   )
+
+  new_initial_estimates <- copy(thailand_initial_estimates)
+  new_initial_estimates[["survival"]] <- new_initial_estimates[["survival"]][age_start <= 80]
+  new_initial_estimates[["survival"]][age_start == 80, age_end := Inf]
+  population <- ccmpp(
+    inputs = new_initial_estimates,
+    settings = list(
+      years = seq(1960, 1995, 5),
+      sexes = c("female", "male"),
+      ages = seq(0, 80, 5),
+      ages_mortality = seq(0, 80, 5),
+      ages_asfr = seq(15, 45, 5)
+    )
+  )
+  assertable::assert_ids(
+    data = population,
+    id_vars = list(year = seq(1960, 2000, 5),
+                   sex = c("female", "male"),
+                   age_start = seq(0, 80, 5)),
+    quiet = T
+  )
+  testthat::expect_identical(
+    names(population),
+    c("year", "sex", "age_start", "age_end", "value")
+  )
+
 })
 
 test_that("test that `ccmpp` gives expected output with immigration/emigration", {
@@ -108,4 +151,44 @@ test_that("test that `ccmpp` works with 'mx', 'ax', 'qx' inputs", {
     names(population),
     c("year", "sex", "age_start", "age_end", "value")
   )
+
+  # collapse to 80+
+  lt <- demCore::agg_lt(
+    dt = lt, id_cols = id_cols,
+    age_mapping = data.table(age_start = seq(0, 80, 5), age_end = c(seq(5, 80, 5), Inf)),
+    present_agg_severity = "skip", quiet = TRUE
+  )
+  hierarchyUtils::gen_length(lt, "age")
+  lt[, mx := qx_ax_to_mx(qx, ax, age_length)]
+
+  # add inputs for mx and ax
+  new_inputs <- copy(demCore::thailand_initial_estimates)
+  new_inputs$mx <- lt[, .SD, .SDcols = c(id_cols, "mx")]
+  setnames(new_inputs$mx, "mx", "value")
+  new_inputs$ax <- lt[, .SD, .SDcols = c(id_cols, "ax")]
+  setnames(new_inputs$ax, "ax", "value")
+  new_inputs$survival <- NULL
+
+  population <- ccmpp(
+    inputs = new_inputs,
+    settings = list(
+      years = seq(1960, 1995, 5),
+      sexes = c("female", "male"),
+      ages = seq(0, 80, 5),
+      ages_mortality = seq(0, 80, 5),
+      ages_asfr = seq(15, 45, 5)
+    )
+  )
+  assertable::assert_ids(
+    data = population,
+    id_vars = list(year = seq(1960, 2000, 5),
+                   sex = c("female", "male"),
+                   age_start = seq(0, 80, 5)),
+    quiet = T
+  )
+  testthat::expect_identical(
+    names(population),
+    c("year", "sex", "age_start", "age_end", "value")
+  )
+
 })


### PR DESCRIPTION
## Describe changes

Currently the mortality inputs to `ccmpp` (like survival, mx, ax etc.) required one extra age group. So if the population was being projected in single year age groups up to 95+ the mortality inputs needed to be single year age groups up to 96+.

This PR adds flexibility so that the mortality inputs can have the same terminal age group as the other inputs.

## What issues are related

Related to ...

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [X] Have you successfully run `devtools::check()` locally?
* [X] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [X] Have you added in tests for the changes included in the PR?
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [X] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.

## Details of PR

The math for this is written out in the [vignette](https://ihmeuw-demographics.github.io/demCore/articles/ccmpp.html#ccmpp-for-the-terminal-age-group-with-out-migration) and is originally from the Preston demography book