### PR TITLE
Add format-long option for life tables

### DIFF
--- a/R/lifetable.R
+++ b/R/lifetable.R
@@ -16,9 +16,12 @@
 #'   based on mx and ax.
 #' @param assert_na \[`logical()`\]\cr Whether to assert that there is no
 #'   missingness.
+#' @inheritParams summarize_lt
 #'
 #' @return \[`data.table()`\]\cr
-#'   Input life table(s) with additional columns: px, lx, dx, Tx, nLx, ex
+#'   Input life table(s) with additional columns: px, lx, dx, Tx, nLx, ex.
+#'   Or, if `format_long` is TRUE, additional columns 'life_table_parameter'
+#'   and 'value' with data long on life table parameter.
 #'
 #' @details
 #' Note that while it typically takes estimation techniques to arrive at mx, ax,
@@ -48,7 +51,11 @@
 #' dt <- lifetable(dt, id_cols = c("sex", "age_start", "age_end"))
 #'
 #' @export
-lifetable <- function(dt, id_cols, preserve_u5 = F, assert_na = T) {
+lifetable <- function(dt,
+                      id_cols,
+                      preserve_u5 = FALSE,
+                      assert_na = TRUE,
+                      format_long = FALSE) {
 
   # validate and prep  ------------------------------------------------------
 
@@ -73,6 +80,9 @@ lifetable <- function(dt, id_cols, preserve_u5 = F, assert_na = T) {
 
   # create `id_cols` without age
   id_cols_no_age <- id_cols[!id_cols %in% c("age_start", "age_end")]
+
+  # check `format_long`
+  assertthat::assert_that(assertthat::is.flag(format_long))
 
   # set key
   original_keys <- key(dt)
@@ -115,8 +125,12 @@ lifetable <- function(dt, id_cols, preserve_u5 = F, assert_na = T) {
   # replace terminal ax with terminal ex
   dt[age_end == Inf, ax := ex]
 
-  # return
-  setkeyv(dt, original_keys)
-  return(dt)
+  # formatting -------------------------------------------------------------
 
-}
+  if (format_long) {
+    dt <- melt(
+      data = dt,
+      measure.vars = c("qx", "mx", "ax", "px", "lx", "dx", "nLx", "Tx", "ex"),
+      variable.name = "life_table_parameter", value.name = "value"
+    )
+    new_keys <- c(origi

--- a/R/lifetable.R
+++ b/R/lifetable.R
@@ -133,4 +133,14 @@ lifetable <- function(dt,
       measure.vars = c("qx", "mx", "ax", "px", "lx", "dx", "nLx", "Tx", "ex"),
       variable.name = "life_table_parameter", value.name = "value"
     )
-    new_keys <- c(origi
+    new_keys <- c(original_keys, "life_table_parameter")
+    setkeyv(dt, new_keys)
+
+  } else {
+    setkeyv(dt, original_keys)
+  }
+
+  # return
+  return(dt)
+
+}

--- a/man/lifetable.Rd
+++ b/man/lifetable.Rd
@@ -4,7 +4,13 @@
 \alias{lifetable}
 \title{Generate a life table with all parameters}
 \usage{
-lifetable(dt, id_cols, preserve_u5 = F, assert_na = T)
+lifetable(
+  dt,
+  id_cols,
+  preserve_u5 = FALSE,
+  assert_na = TRUE,
+  format_long = FALSE
+)
 }
 \arguments{
 \item{dt}{[\code{data.table()}]\cr
@@ -21,10 +27,17 @@ based on mx and ax.}
 
 \item{assert_na}{[\code{logical()}]\cr Whether to assert that there is no
 missingness.}
+
+\item{format_long}{[\code{logical(1)}]\cr
+Whether to format output with a 'life_table_parameter' column and a column
+for each summary statistic (rather than a column for each
+'life_table_parameter' and summary statistic pair).}
 }
 \value{
 [\code{data.table()}]\cr
-Input life table(s) with additional columns: px, lx, dx, Tx, nLx, ex
+Input life table(s) with additional columns: px, lx, dx, Tx, nLx, ex.
+Or, if \code{format_long} is TRUE, additional columns 'life_table_parameter'
+and 'value' with data long on life table parameter.
 }
 \description{
 Given a \code{data.table} with at least two of variables mx, ax, and

--- a/tests/testthat/test-lifetable.R
+++ b/tests/testthat/test-lifetable.R
@@ -49,3 +49,12 @@ test_that("test that `lifetable` works when missing qx", {
                                        "age_length", param_cols)))
   assertable::assert_values(dt, param_cols, "not_na", quiet = T)
 })
+
+test_that("test that `lifetable` with long format works", {
+  dt <- lifetable(dt, id_cols = c("age_start", "age_end", "sex"), format_long = T)
+  testthat::expect_equal(
+    sort(names(dt)),
+    sort(c("sex", "age_start", "age_end", "age_length",
+           "life_table_parameter", "value"))
+  )
+})


### PR DESCRIPTION
## Describe changes

Add `format_long` options for life tables, to make output long on life table parameter.

## What issues are related

Resolves #73 

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [x] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [x] Have you successfully run `devtools::check()` locally?
* [x] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [x] Have you added in tests for the changes included in the PR?
* [x] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.