### PR TITLE
refactor: Make demViz a suggested package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Suggests:
     covr,
     devtools,
     ggplot2,
-    LexisPlotR
+    LexisPlotR,
+    demViz
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
@@ -37,8 +38,7 @@ Imports:
     purrr,
     Rdpack,
     hierarchyUtils,
-    demUtils,
-    demViz
+    demUtils
 Remotes:
     ihmeuw-demographics/hierarchyUtils,
     ihmeuw-demographics/demUtils,


### PR DESCRIPTION
Change demViz from an imported package to a suggested package. demViz is only used in a vignette, so functionality of demCore should be unaffected.
