### PR TITLE
fix: replace usage of pryr with lobstr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     checkmate,
     assertthat,
     testthat,
-    pryr,
+    lobstr,
     purrr,
     Rdpack,
     hierarchyUtils,

--- a/tests/testthat/test-gen_u5_ax.R
+++ b/tests/testthat/test-gen_u5_ax.R
@@ -38,9 +38,9 @@ test_that("test that `gen_u5_ax_from_mx` gives errors when it should", {
 
 test_that("test that `gen_u5_ax_from_mx` modifies in place", {
   test_dt <- copy(dt)
-  mem1 <- pryr::address(test_dt) # memory address before
+  mem1 <- lobstr::obj_addr(test_dt) # memory address before
   gen_u5_ax_from_mx(test_dt, id_cols = c("age_start", "age_end", "sex", "location"))
-  mem2 <- pryr::address(test_dt) # memory address after
+  mem2 <- lobstr::obj_addr(test_dt) # memory address after
   testthat::expect_equal(mem1, mem2)
 })
 


### PR DESCRIPTION
## Describe changes

The pryr package has been superseded by lobster since 2020.
